### PR TITLE
Improved Database Performance and QOL Feautres

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # file-fortress
+
 A file hosting service
 
 ## Requirements
@@ -6,6 +7,19 @@ A file hosting service
 * [Docker Compose](https://docs.docker.com/compose/install/)
 
 ## Installation/Setup
+
+### Database
+
+The MariaDB container requires some environment variables to be set.
+When using Docker Compose, the file `mariadb/.env` should be created with the following values filled in:
+
+```
+MARIADB_ROOT_PASSWORD="<ROOT PASSWORD>"
+MARIADB_USER="<USER ACCOUNT>"
+MARIADB_PASSWORD="<USER PASSSWORD>"
+```
+
+Note the default database can be changed from `filefort` via the `MARIADB_DATABASE` environment variable in `docker-compose.yml`.
 
 ## Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,7 @@ services:
   mariadb:
     build: ./mariadb
     container_name: mariadb
+    environment:
+      - "MARIADB_DATABASE=filefort"
     env_file:
       - mariadb/.env

--- a/mariadb/dockerfile
+++ b/mariadb/dockerfile
@@ -1,3 +1,3 @@
 FROM mariadb:latest
 
-COPY schema.sql /docker-entrypoint-initdb.d/
+COPY init.sql /docker-entrypoint-initdb.d/

--- a/mariadb/dockerfile
+++ b/mariadb/dockerfile
@@ -1,3 +1,4 @@
 FROM mariadb:latest
 
 COPY init.sql /docker-entrypoint-initdb.d/
+COPY procedures.sql /docker-entrypoint-initdb.d/

--- a/mariadb/dockerfile
+++ b/mariadb/dockerfile
@@ -1,4 +1,5 @@
 FROM mariadb:latest
 
-COPY init.sql /docker-entrypoint-initdb.d/
-COPY procedures.sql /docker-entrypoint-initdb.d/
+COPY init.sql /docker-entrypoint-initdb.d/sql/
+COPY procedures.sql /docker-entrypoint-initdb.d/sql/
+COPY init.sh /docker-entrypoint-initdb.d/

--- a/mariadb/init.sh
+++ b/mariadb/init.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/sh
+
+mariadb -u root -p$MARIADB_ROOT_PASSWORD $MARIADB_DATABASE < /docker-entrypoint-initdb.d/sql/init.sql
+mariadb -u root -p$MARIADB_ROOT_PASSWORD $MARIADB_DATABASE < /docker-entrypoint-initdb.d/sql/procedures.sql

--- a/mariadb/init.sql
+++ b/mariadb/init.sql
@@ -20,7 +20,7 @@ CREATE TABLE files (
     url VARCHAR(255),
     mime_type VARCHAR(31),
     expires DATETIME,
-    privacy ENUM('public', 'share', 'private') DEFAULT 'public',
+    privacy ENUM('public', 'share', 'private') DEFAULT 'public' NOT NULL,
     PRIMARY KEY (id),
     INDEX(uploader_id, mime_type),
     FOREIGN KEY (uploader_id) REFERENCES users(id)
@@ -30,6 +30,9 @@ CREATE TABLE permissions (
     file_id INT UNSIGNED,
     user_id UUID,
     permission ENUM('owner', 'view'),
+    INDEX(file_id),
+    INDEX(user_id),
+    INDEX(user_id, permission),
     FOREIGN KEY (file_id) REFERENCES files(id)
         ON DELETE CASCADE,
     FOREIGN KEY (user_id) REFERENCES users(id)

--- a/mariadb/init.sql
+++ b/mariadb/init.sql
@@ -1,7 +1,3 @@
-CREATE DATABASE filefort;
-
-USE filefort;
-
 CREATE TABLE users (
     id UUID DEFAULT UUID(),
     name VARCHAR(31) NOT NULL,

--- a/mariadb/init.sql
+++ b/mariadb/init.sql
@@ -35,3 +35,15 @@ CREATE TABLE permissions (
     FOREIGN KEY (user_id) REFERENCES users(id)
         ON DELETE CASCADE
 );
+
+DELIMITER //
+
+CREATE TRIGGER add_owner_permissions
+AFTER INSERT ON files
+FOR EACH ROW
+BEGIN
+    INSERT INTO permissions
+    VALUES (NEW.id, NEW.uploader_id, 'owner');
+END;//
+
+DELIMITER ;

--- a/mariadb/procedures.sql
+++ b/mariadb/procedures.sql
@@ -1,0 +1,32 @@
+USE filefort;
+
+DELIMITER //
+
+CREATE OR REPLACE PROCEDURE RemoveExpired (IN p_expire_date DATETIME, OUT p_remove_count INT)
+BEGIN
+    DECLARE v_error_message VARCHAR(255);
+    DECLARE exit_handler BOOLEAN DEFAULT FALSE;
+
+    -- Declare the handler for SQL exceptions
+    DECLARE CONTINUE HANDLER FOR SQLEXCEPTION
+        SET exit_handler = TRUE;
+
+    START TRANSACTION;
+
+    DELETE FROM files
+    WHERE expires < p_expire_date;
+
+    -- Get the number of rows deleted
+    SELECT ROW_COUNT() INTO p_remove_count;
+
+    IF NOT exit_handler THEN
+        COMMIT;
+    ELSE
+        ROLLBACK;
+        -- Log the error
+        SELECT CONCAT('Error in RemoveExpired procedure: ', ERROR_MESSAGE()) INTO v_error_message;
+    END IF;
+END;
+//
+
+DELIMITER ;

--- a/mariadb/procedures.sql
+++ b/mariadb/procedures.sql
@@ -1,5 +1,3 @@
-USE filefort;
-
 DELIMITER //
 
 CREATE OR REPLACE PROCEDURE RemoveExpired (IN p_expire_date DATETIME, OUT p_remove_count INT)


### PR DESCRIPTION
# Description

Added the following features

* a file uploader is automatically granted owner permissions
* indexes on permissions table
* stored procedure `RemoveExpired` to remove files past a certain datetime
* enviornment variable `MARIADB_DATABASE` is now used where relevant

# Why

The a file uploader being the default owner is intended behavior.

Once implemented almost every resource fetch will require a permissions lookup. As such, indexed the relevant columns of the table.

Stored procedures grant additional safety when executing queries. The procedure uses a transaction to ensure no data loss.

Using the environment variable is to avoid situation like in #7 , additional configuration details have been added in `README.md` to avoid any confusion.

# Testing

Local tests run, as per #6 automated tests have not yet been configured for this repo.