### PR TITLE
fixed startup script for AWS

### DIFF
--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -1,5 +1,5 @@
 # install git and docker in the instance
-sudo dnf in docker git
+sudo dnf in docker git -y
 
 # enable the docker daemon
 sudo systemctl enable --now docker


### PR DESCRIPTION
the `dnf` install did not have -y at the end so it asked the user for input 
the docker group was also not created for `ec2-user` to join